### PR TITLE
[tools-802] Удалить из плагина fancybox лишнее событие

### DIFF
--- a/fancybox/jquery.fancybox.js
+++ b/fancybox/jquery.fancybox.js
@@ -353,12 +353,6 @@
 
 			loading.hide();
 
-			$.event.trigger('fancybox-onCleanup', [
-				currentArray,
-				currentIndex,
-				currentOpts
-			]);
-
 			if (wrap.is(":visible") && false === currentOpts.onCleanup(currentArray, currentIndex, currentOpts)) {
 				$.event.trigger('fancybox-cancel');
 


### PR DESCRIPTION
В плагине событие `fancybox-onCleanup` не должно срабатывать в этом месте:

```js
_show = function() {
	var pos, equal;

	loading.hide();

	$.event.trigger('fancybox-onCleanup', [
		currentArray,
		currentIndex,
		currentOpts
	]);
```
