### PR TITLE
[mg-132814] 3273 - Мобильная версия ОЭТ - Fancybox. Перенести изменения из версии 1.4 в 1.5

### DIFF
--- a/fancybox/jquery.fancybox.js
+++ b/fancybox/jquery.fancybox.js
@@ -1383,6 +1383,9 @@
 		SCROLLBAR_WIDTH = obj.offsetWidth - obj.clientWidth;
 		obj.parentNode.removeChild(obj);
 
+		// Добавление css-переменной с шириной скроллбара
+		$(':root')[0].style.setProperty('--modal-scrollbar-width', SCROLLBAR_WIDTH + 'px');
+
 		// добавление стиля в шапку
 		// http://stackoverflow.com/questions/524696/how-to-create-a-style-tag-with-javascript#answer-524721
 		var css = '.fancybox__shift{margin-right: '+ SCROLLBAR_WIDTH +'px !important;}';


### PR DESCRIPTION
Добавлена css-переменная с указанием ширины скролла. Может быть полезна для absolute и fixed слоёв, у которых ширина 100% и не учитывают видимый скролл fancybox.

Пример применения:

```css
.fancybox__shift .fixed_div {
    width: calc(100% - var(--modal-scrollbar-width, 0));
}
```

При появлении окна ширина слоя будет меняться с учётом скрола.
