### PR TITLE
[mg-132814] 3273 - Мобильная версия ОЭТ - Fancybox. Перенести изменения из версии 1.4 в 1.5

### DIFF
--- a/fancybox/jquery.fancybox.css
+++ b/fancybox/jquery.fancybox.css
@@ -2,7 +2,7 @@
  * Copyright (c) 2008 - 2010 Janis Skarnelis
  * Updated by Sergei Vasilev (https://github.com/Ser-Gen)
  *
- * Version: 1.6.2
+ * Version: 1.6.4
  *
  * Dual licensed under the MIT and GPL licenses:
  *   http://www.opensource.org/licenses/mit-license.php

--- a/fancybox/jquery.fancybox.js
+++ b/fancybox/jquery.fancybox.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2008 - 2010 Janis Skarnelis
  * Updated by Sergei Vasilev (https://github.com/Ser-Gen)
  *
- * Version: 1.6.2
+ * Version: 1.6.4
  *
  * Dual licensed under the MIT and GPL licenses:
  *	 http://www.opensource.org/licenses/mit-license.php
@@ -36,12 +36,21 @@
 		 * Private methods 
 		 */
 
+		_removeScrollbarWidthProp = function () {
+			document.documentElement.style.removeProperty('--fancybox-scrollbar-width' );
+		},
+
 		_scrollBarCheck = function() {
 			if ($('html').hasScrollBarY() || $('html').css('overflow') === 'scroll' || $('html').css('overflow-y') === 'scroll') {
 				$('html').addClass('fancybox__shift');
+
+				if (SCROLLBAR_WIDTH) {
+					document.documentElement.style.setProperty('--fancybox-scrollbar-width', SCROLLBAR_WIDTH + 'px');
+				}
 			}
 			else {
 				$('html').removeClass('fancybox__shift');
+				_removeScrollbarWidthProp();
 			};
 
 			if (actionEvent === 'touchstart') {
@@ -101,7 +110,7 @@
 				return;
 			}
 
-			$(':root')[0].style.setProperty('--modal-max-height', window.innerHeight + 'px');
+			document.documentElement.style.setProperty('--fancybox-max-height', window.innerHeight + 'px');
 		},
 
 		_isReadyType = function (type) {
@@ -1233,6 +1242,7 @@
 			currentOpts.onClosed(currentArray, currentIndex, currentOpts);
 
 			$('html').removeClass('fancybox__shift fancybox__lock fancybox__touch');
+			_removeScrollbarWidthProp();
 
 			if (actionEvent === 'touchstart') {
 				$('body').css({

--- a/index.html
+++ b/index.html
@@ -27,6 +27,14 @@
 	.fancy h1 {
 		margin-top: 0;
 	}
+	.floatElement {
+		position: fixed;
+		top: 0;
+		right: var(--fancybox-scrollbar-width, 0);
+		width: 10px;
+		height: 10px;
+		background-color: green;
+	}
 	</style>
 
 	<script>
@@ -256,6 +264,8 @@
 	<a href="#" class="back">Back!</a>
   </div>
 </div>
+
+<div class="floatElement"></div>
 
 </body>
 </html>


### PR DESCRIPTION
Добавлена css-переменная с указанием ширины скролла. Может быть полезна для absolute и fixed слоёв, не учитывающих видимый скролл fancybox.

Пример применения:

```css
.fixed_div {
    width: calc(100% - var(--modal-scrollbar-width, 0));
}
```

При появлении окна ширина слоя будет меняться с учётом скролла.